### PR TITLE
Feature/data block no empty lines

### DIFF
--- a/iec62056_21/messages.py
+++ b/iec62056_21/messages.py
@@ -134,7 +134,7 @@ class DataLine(Iec6205621Data):
 class DataBlock(Iec6205621Data):
     """
     A data block is a list of DataLines, each ended with a the line end characters
-    \n\r
+    \r\n
     """
 
     def __init__(self, data_lines):

--- a/iec62056_21/messages.py
+++ b/iec62056_21/messages.py
@@ -142,7 +142,7 @@ class DataBlock(Iec6205621Data):
 
     def to_representation(self):
         lines_rep = [
-            (line.to_representation() + constants.LINE_END) for line in self.data_lines
+            (line.to_representation() + constants.LINE_END) for line in self.data_lines if line.data_sets
         ]
         return "".join(lines_rep)
 


### PR DESCRIPTION
```
>           assert payload_received == payload_sent, "payloads rx≠tx"
E           AssertionError: payloads rx≠tx
E           assert '\x02F.F(00)\r\n1.8.0(000052.337*kWh)\r\n2.8.0(000376.432*kWh)\r\n3.8.0(000145.875*kvarh)\r\n4.8.0(000010.724*kvarh)\r\n15.8.0(000428.769*kWh)\r\n32.7(231*V)\r\n52.7(231*V)\r\n72.7(231*V)\r\n31.7(00.000*A)\r\n51.7(00.000*A)\r\n71.7(00.000*A)\r\n13.7(-.--)\r\n14.7(50.0*Hz)\r\nC.1.0(40799390)\r\n0.0(40799390 )\r\nC.1.1( )\r\n0.2.0(M29)\r\n16.7(000.00*kW)\r\n131.7(000.00*kVAr)\r\nC.5.0(6402)\r\nC.7.0(0064)\r\n\r\n!\r\n\x03\x0f' == '\x02F.F(00)\r\n1.8.0(000052.337*kWh)\r\n2.8.0(000376.432*kWh)\r\n3.8.0(000145.875*kvarh)\r\n4.8.0(000010.724*kvarh)\r\n15.8.0(000428.769*kWh)\r\n32.7(231*V)\r\n52.7(231*V)\r\n72.7(231*V)\r\n31.7(00.000*A)\r\n51.7(00.000*A)\r\n71.7(00.000*A)\r\n13.7(-.--)\r\n14.7(50.0*Hz)\r\nC.1.0(40799390)\r\n0.0(40799390 )\r\nC.1.1( )\r\n0.2.0(M29)\r\n16.7(000.00*kW)\r\n131.7(000.00*kVAr)\r\nC.5.0(6402)\r\nC.7.0(0064)\r\n!\r\n\x03\x08'
E               F.F(00)
E               1.8.0(000052.337*kWh)
E               2.8.0(000376.432*kWh)
E               3.8.0(000145.875*kvarh)
E               4.8.0(000010.724*kvarh)
E               15.8.0(000428.769*kWh)
E               32.7(231*V)
E               52.7(231*V)
E               72.7(231*V)
E               31.7(00.000*A)
E               51.7(00.000*A)
E               71.7(00.000*A)
E               13.7(-.--)
E               14.7(50.0*Hz)
E               C.1.0(40799390)
E               0.0(40799390 )
E               C.1.1( )
E               0.2.0(M29)
E               16.7(000.00*kW)
E               131.7(000.00*kVAr)
E               C.5.0(6402)
E               C.7.0(0064)
E             + 
E               !
E             - 
E             + 

test_02_simulator.py:73: AssertionError

```